### PR TITLE
A FakerProvider for code bases with a PSR-11 compliant DI container

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
 services:
-  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory('/path/to/container.php', 'myContainer', 'FakerId')
+  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+    arguments:
+      phpContainerPath: /path/to/container.php
+      ...
 ```
 
 The first parameter for this factory specifies the path to the PHP file that configures

--- a/README.md
+++ b/README.md
@@ -79,29 +79,40 @@ can use the PsrContainerFakerProviderFactory.
 parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+    psr:
+      phpContainerPath: /path/to/container.php
+      ...
 services:
   - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
     arguments:
-      phpContainerPath: /path/to/container.php
+      phpContainerPath: %fakerstan.psr.phpContainerPath%
       ...
 ```
 
-The first parameter for this factory specifies the path to the PHP file that configures
-the container. If this configuration file assigns the configured container to a global
-variable, the second parameter is used to indicate the name of that variable. If this
-parameter is null (which is the default), this indicates that the configuration file
-returns the container itself. The third parameter indicates the ID that the container
-uses for retrieving the Faker Generator. By default, this parameter is the Generator's
-class name (ie. `Faker\Generator`).
+The parameters that can be set (and subsequently injected as arguments to the factory) are:
+* `phpContainerPath`: the path to the PHP file that configures the container.
+* `setsVariable`: if the file that configures the container assigns it to a global variable,
+this parameter is used to indicate the name of that variable. If the container file returns
+the container itself, set this parameter is null (which is the default).
+* `containerFakerId`: the ID that the container uses for retrieving the Faker Generator. By
+default, this parameter is the Generator's class name (ie. `Faker\Generator`).
 
 If using Symfony, for example, you could use something like:
 
 ```neon
+parameters:
+  fakerstan:
+    fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+    psr:
+      phpContainerPath: /opt/project/var/cache/dev/App_KernelDevDebugContainer.php
 services:
-- class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory('/opt/project/var/cache/dev/App_KernelDevDebugContainer.php')
+  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+    arguments:
+      phpContainerPath: %fakerstan.psr.phpContainerPath%
 ```
 
-as the defaults for the additional parameters are correct for Symfony.
+to set the path to the Symfony container and then inject that path to the factory. The default
+values for the additional parameters are correct for Symfony.
 
 If not using Laravel or some other PSR-11 compliant container, you can specify a custom
 factory class in the `phpstan.neon(.dist)` configuration file:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ can use the PsrContainerFakerProviderFactory.
 parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
-    psr:
+    psrProvider:
       phpContainerPath: /path/to/container.php
       ...
 ```
@@ -98,7 +98,7 @@ If using Symfony, for example, you could use something like:
 parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
-    psr:
+    psrProvider:
       phpContainerPath: /opt/project/var/cache/dev/App_KernelDevDebugContainer.php
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,9 @@ parameters:
     psr:
       phpContainerPath: /path/to/container.php
       ...
-services:
-  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
-    arguments:
-      phpContainerPath: %fakerstan.psr.phpContainerPath%
-      ...
 ```
 
-The parameters that can be set (and subsequently injected as arguments to the factory) are:
+The parameters that can be set are:
 * `phpContainerPath`: the path to the PHP file that configures the container.
 * `setsVariable`: if the file that configures the container assigns it to a global variable,
 this parameter is used to indicate the name of that variable. If the container file returns
@@ -105,13 +100,9 @@ parameters:
     fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
     psr:
       phpContainerPath: /opt/project/var/cache/dev/App_KernelDevDebugContainer.php
-services:
-  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
-    arguments:
-      phpContainerPath: %fakerstan.psr.phpContainerPath%
 ```
 
-to set the path to the Symfony container and then inject that path to the factory. The default
+to use the PsrContainerFakerProviderFactory and set the path to the Symfony container. The default
 values for the additional parameters are correct for Symfony.
 
 If not using Laravel or some other PSR-11 compliant container, you can specify a custom

--- a/README.md
+++ b/README.md
@@ -69,8 +69,39 @@ Faker instance used in the project (or at least an instance with the custom
 providers added to it).
 
 If using Laravel, FakerStan will automatically resolve the faker instance from
-the container using the `fake()` helper function. If not using Laravel, you can
-specify a custom factory class in the `phpstan.neon(.dist)` configuration file:
+the container using the `fake()` helper function.
+
+If not using Laravel, but you are using a framework or environment that has a PSR-11
+compliant DI container (and assuming this container is configured via a PHP file), you
+can use the PsrContainerFakerProviderFactory.
+
+```neon
+parameters:
+  fakerstan:
+    fakerProviderFactory: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+services:
+  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory('/path/to/container.php', 'myContainer', 'FakerId')
+```
+
+The first parameter for this factory specifies the path to the PHP file that configures
+the container. If this configuration file assigns the configured container to a global
+variable, the second parameter is used to indicate the name of that variable. If this
+parameter is null (which is the default), this indicates that the configuration file
+returns the container itself. The third parameter indicates the ID that the container
+uses for retrieving the Faker Generator. By default, this parameter is the Generator's
+class name (ie. `Faker\Generator`).
+
+If using Symfony, for example, you could use something like:
+
+```neon
+services:
+- class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory('/opt/project/var/cache/dev/App_KernelDevDebugContainer.php')
+```
+
+as the defaults for the additional parameters are correct for Symfony.
+
+If not using Laravel or some other PSR-11 compliant container, you can specify a custom
+factory class in the `phpstan.neon(.dist)` configuration file:
 
 ```neon
 parameters:

--- a/extension.neon
+++ b/extension.neon
@@ -1,9 +1,18 @@
 parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\FakerProviderFactory
+    psr:
+      phpContainerPath: <Set path in your configuration>
+      setsVariable: null
+      containerFakerId: Faker\Generator
 parametersSchema:
   fakerstan: structure([
     fakerProviderFactory: string(),
+    psr: structure([
+      phpContainerPath: string(),
+      setsVariable: schema(string(), nullable()),
+      containerFakerId: string()
+    ])
   ])
 services:
   - class: CalebDW\Fakerstan\FakerProviderFactory

--- a/extension.neon
+++ b/extension.neon
@@ -2,14 +2,14 @@ parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\FakerProviderFactory
     psrProvider:
-      phpContainerPath: <Set path in your configuration>
+      phpContainerPath: null
       setsVariable: null
       containerFakerId: Faker\Generator
 parametersSchema:
   fakerstan: structure([
     fakerProviderFactory: string(),
     psrProvider: structure([
-      phpContainerPath: string(),
+      phpContainerPath: schema(string(), nullable()),
       setsVariable: schema(string(), nullable()),
       containerFakerId: string()
     ])

--- a/extension.neon
+++ b/extension.neon
@@ -16,6 +16,11 @@ parametersSchema:
   ])
 services:
   - class: CalebDW\Fakerstan\FakerProviderFactory
+  - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
+    arguments:
+      phpContainerPath: %fakerstan.psr.phpContainerPath%
+      setsVariable: %fakerstan.psr.setsVariable%
+      containerFakerId: %fakerstan.psr.containerFakerId%
   - class: CalebDW\Fakerstan\FakerProvider
     factory: @%fakerstan.fakerProviderFactory%::create
   - class: CalebDW\Fakerstan\ProviderExtension

--- a/extension.neon
+++ b/extension.neon
@@ -1,14 +1,14 @@
 parameters:
   fakerstan:
     fakerProviderFactory: CalebDW\Fakerstan\FakerProviderFactory
-    psr:
+    psrProvider:
       phpContainerPath: <Set path in your configuration>
       setsVariable: null
       containerFakerId: Faker\Generator
 parametersSchema:
   fakerstan: structure([
     fakerProviderFactory: string(),
-    psr: structure([
+    psrProvider: structure([
       phpContainerPath: string(),
       setsVariable: schema(string(), nullable()),
       containerFakerId: string()
@@ -18,9 +18,9 @@ services:
   - class: CalebDW\Fakerstan\FakerProviderFactory
   - class: CalebDW\Fakerstan\PsrContainerFakerProviderFactory
     arguments:
-      phpContainerPath: %fakerstan.psr.phpContainerPath%
-      setsVariable: %fakerstan.psr.setsVariable%
-      containerFakerId: %fakerstan.psr.containerFakerId%
+      phpContainerPath: %fakerstan.psrProvider.phpContainerPath%
+      setsVariable: %fakerstan.psrProvider.setsVariable%
+      containerFakerId: %fakerstan.psrProvider.containerFakerId%
   - class: CalebDW\Fakerstan\FakerProvider
     factory: @%fakerstan.fakerProviderFactory%::create
   - class: CalebDW\Fakerstan\ProviderExtension

--- a/src/PsrContainerFakerProvider.php
+++ b/src/PsrContainerFakerProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan;
+
+use Faker\Generator;
+use Psr\Container\ContainerInterface;
+
+final class PsrContainerFakerProvider implements FakerProvider
+{
+    private ?Generator $generatorFromContainer = null;
+
+    public function __construct(
+        private string $phpContainerPath,
+        private ?string $setsVariable,
+        private string $containerFakerId,
+    ) {
+    }
+
+    public function getFaker(): Generator
+    {
+        if (is_null($this->generatorFromContainer)) {
+            $this->generatorFromContainer = $this->getGeneratorFromContainer();
+        }
+
+        return $this->generatorFromContainer;
+    }
+
+    private function getGeneratorFromContainer(): Generator
+    {
+        if (! is_readable($this->phpContainerPath)) {
+            throw new \RuntimeException('Could not read container PHP file');
+        }
+
+        // Include the container file and store the return value, just in case.
+        $maybeContainer = require_once $this->phpContainerPath;
+
+        // If the code in that file returns nothing, the require_once will return 1.
+        if (is_null($this->setsVariable) && ($maybeContainer === 1)) {
+            throw new \RuntimeException('Container file was expected to return the container, but it returned nothing');
+        }
+
+        // If we didn't expect it to be returned, check the variable that we said it would be in.
+        if (is_string($this->setsVariable)) {
+            $definedVariables = get_defined_vars();
+            if (! array_key_exists($this->setsVariable, $definedVariables)) {
+                throw new \RuntimeException('Container file does not set variable '.$this->setsVariable);
+            }
+
+            $maybeContainer = $definedVariables[$this->setsVariable];
+        }
+
+        // Check that we got something that looks like a container.
+        if (! $maybeContainer instanceof ContainerInterface) {
+            throw new \RuntimeException('Retrieved container is not a '.ContainerInterface::class);
+        }
+
+        // Does the container have something with the expected Faker Generator ID?
+        if (! $maybeContainer->has($this->containerFakerId)) {
+            throw new \RuntimeException('Container does not have entry with ID '.$this->containerFakerId);
+        }
+
+        // Make sure that we retrieved an actual Generator.
+        $containerFaker = $maybeContainer->get($this->containerFakerId);
+        if (! $containerFaker instanceof Generator) {
+            throw new \RuntimeException('Container entry with ID '.$this->containerFakerId.' is not a '.Generator::class);
+        }
+
+        return $containerFaker;
+    }
+}

--- a/src/PsrContainerFakerProvider.php
+++ b/src/PsrContainerFakerProvider.php
@@ -34,7 +34,7 @@ final class PsrContainerFakerProvider implements FakerProvider
             throw new RuntimeException('Could not read container PHP file');
         }
 
-        $maybeContainer = require_once $this->phpContainerPath;
+        $maybeContainer = require $this->phpContainerPath;
 
         if (is_null($this->setsVariable) && ($maybeContainer === 1)) {
             throw new RuntimeException('Container file was expected to return the container, but it returned nothing');

--- a/src/PsrContainerFakerProvider.php
+++ b/src/PsrContainerFakerProvider.php
@@ -34,15 +34,12 @@ final class PsrContainerFakerProvider implements FakerProvider
             throw new RuntimeException('Could not read container PHP file');
         }
 
-        // Include the container file and store the return value, just in case.
         $maybeContainer = require_once $this->phpContainerPath;
 
-        // If the code in that file returns nothing, the require_once will return 1.
         if (is_null($this->setsVariable) && ($maybeContainer === 1)) {
             throw new RuntimeException('Container file was expected to return the container, but it returned nothing');
         }
 
-        // If we didn't expect it to be returned, check the variable that we said it would be in.
         if (is_string($this->setsVariable)) {
             $definedVariables = get_defined_vars();
             if (! array_key_exists($this->setsVariable, $definedVariables)) {
@@ -52,17 +49,14 @@ final class PsrContainerFakerProvider implements FakerProvider
             $maybeContainer = $definedVariables[$this->setsVariable];
         }
 
-        // Check that we got something that looks like a container.
         if (! $maybeContainer instanceof ContainerInterface) {
             throw new RuntimeException('Retrieved container is not a '.ContainerInterface::class);
         }
 
-        // Does the container have something with the expected Faker Generator ID?
         if (! $maybeContainer->has($this->containerFakerId)) {
             throw new RuntimeException('Container does not have entry with ID '.$this->containerFakerId);
         }
 
-        // Make sure that we retrieved an actual Generator.
         $containerFaker = $maybeContainer->get($this->containerFakerId);
         if (! $containerFaker instanceof Generator) {
             throw new RuntimeException('Container entry with ID '.$this->containerFakerId.' is not a '.Generator::class);

--- a/src/PsrContainerFakerProvider.php
+++ b/src/PsrContainerFakerProvider.php
@@ -31,7 +31,7 @@ final class PsrContainerFakerProvider implements FakerProvider
     private function getGeneratorFromContainer(): Generator
     {
         if (! is_readable($this->phpContainerPath)) {
-            throw new RuntimeException('Could not read container PHP file');
+            throw new RuntimeException('Could not read container PHP file ('.$this->phpContainerPath.')');
         }
 
         $maybeContainer = require $this->phpContainerPath;

--- a/src/PsrContainerFakerProvider.php
+++ b/src/PsrContainerFakerProvider.php
@@ -6,6 +6,7 @@ namespace CalebDW\Fakerstan;
 
 use Faker\Generator;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 final class PsrContainerFakerProvider implements FakerProvider
 {
@@ -30,7 +31,7 @@ final class PsrContainerFakerProvider implements FakerProvider
     private function getGeneratorFromContainer(): Generator
     {
         if (! is_readable($this->phpContainerPath)) {
-            throw new \RuntimeException('Could not read container PHP file');
+            throw new RuntimeException('Could not read container PHP file');
         }
 
         // Include the container file and store the return value, just in case.
@@ -38,14 +39,14 @@ final class PsrContainerFakerProvider implements FakerProvider
 
         // If the code in that file returns nothing, the require_once will return 1.
         if (is_null($this->setsVariable) && ($maybeContainer === 1)) {
-            throw new \RuntimeException('Container file was expected to return the container, but it returned nothing');
+            throw new RuntimeException('Container file was expected to return the container, but it returned nothing');
         }
 
         // If we didn't expect it to be returned, check the variable that we said it would be in.
         if (is_string($this->setsVariable)) {
             $definedVariables = get_defined_vars();
             if (! array_key_exists($this->setsVariable, $definedVariables)) {
-                throw new \RuntimeException('Container file does not set variable '.$this->setsVariable);
+                throw new RuntimeException('Container file does not set variable '.$this->setsVariable);
             }
 
             $maybeContainer = $definedVariables[$this->setsVariable];
@@ -53,18 +54,18 @@ final class PsrContainerFakerProvider implements FakerProvider
 
         // Check that we got something that looks like a container.
         if (! $maybeContainer instanceof ContainerInterface) {
-            throw new \RuntimeException('Retrieved container is not a '.ContainerInterface::class);
+            throw new RuntimeException('Retrieved container is not a '.ContainerInterface::class);
         }
 
         // Does the container have something with the expected Faker Generator ID?
         if (! $maybeContainer->has($this->containerFakerId)) {
-            throw new \RuntimeException('Container does not have entry with ID '.$this->containerFakerId);
+            throw new RuntimeException('Container does not have entry with ID '.$this->containerFakerId);
         }
 
         // Make sure that we retrieved an actual Generator.
         $containerFaker = $maybeContainer->get($this->containerFakerId);
         if (! $containerFaker instanceof Generator) {
-            throw new \RuntimeException('Container entry with ID '.$this->containerFakerId.' is not a '.Generator::class);
+            throw new RuntimeException('Container entry with ID '.$this->containerFakerId.' is not a '.Generator::class);
         }
 
         return $containerFaker;

--- a/src/PsrContainerFakerProviderFactory.php
+++ b/src/PsrContainerFakerProviderFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan;
+
+use Faker\Generator;
+
+class PsrContainerFakerProviderFactory
+{
+    private static string $phpContainerPath;
+    private static ?string $setsVariable;
+    private static string $containerFakerId;
+
+    public function __construct(
+        string $phpContainerPath,
+        ?string $setsVariable = null,
+        string $containerFakerId = Generator::class,
+    ) {
+        self::$phpContainerPath = $phpContainerPath;
+        self::$setsVariable = $setsVariable;
+        self::$containerFakerId = $containerFakerId;
+    }
+
+    public static function create(): FakerProvider
+    {
+        return new PsrContainerFakerProvider(
+            self::$phpContainerPath,
+            self::$setsVariable,
+            self::$containerFakerId,
+        );
+    }
+}

--- a/src/PsrContainerFakerProviderFactory.php
+++ b/src/PsrContainerFakerProviderFactory.php
@@ -8,26 +8,19 @@ use Faker\Generator;
 
 class PsrContainerFakerProviderFactory
 {
-    private static string $phpContainerPath;
-    private static ?string $setsVariable;
-    private static string $containerFakerId;
-
     public function __construct(
-        string $phpContainerPath,
-        ?string $setsVariable = null,
-        string $containerFakerId = Generator::class,
+        private string $phpContainerPath,
+        private ?string $setsVariable = null,
+        private string $containerFakerId = Generator::class,
     ) {
-        self::$phpContainerPath = $phpContainerPath;
-        self::$setsVariable = $setsVariable;
-        self::$containerFakerId = $containerFakerId;
     }
 
-    public static function create(): FakerProvider
+    public function create(): FakerProvider
     {
         return new PsrContainerFakerProvider(
-            self::$phpContainerPath,
-            self::$setsVariable,
-            self::$containerFakerId,
+            $this->phpContainerPath,
+            $this->setsVariable,
+            $this->containerFakerId,
         );
     }
 }

--- a/src/PsrContainerFakerProviderFactory.php
+++ b/src/PsrContainerFakerProviderFactory.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace CalebDW\Fakerstan;
 
 use Faker\Generator;
+use RuntimeException;
 
 class PsrContainerFakerProviderFactory
 {
     public function __construct(
-        private string $phpContainerPath,
+        private ?string $phpContainerPath = null,
         private ?string $setsVariable = null,
         private string $containerFakerId = Generator::class,
     ) {
@@ -17,6 +18,10 @@ class PsrContainerFakerProviderFactory
 
     public function create(): FakerProvider
     {
+        if (is_null($this->phpContainerPath)) {
+            throw new RuntimeException('PsrContainerFakerProviderFactory requires a value for "parameters › fakerstan › psrProvider › phpContainerPath"');
+        }
+
         return new PsrContainerFakerProvider(
             $this->phpContainerPath,
             $this->setsVariable,

--- a/src/PsrContainerFakerProviderFactory.php
+++ b/src/PsrContainerFakerProviderFactory.php
@@ -19,7 +19,7 @@ class PsrContainerFakerProviderFactory
     public function create(): FakerProvider
     {
         if (is_null($this->phpContainerPath)) {
-            throw new RuntimeException('PsrContainerFakerProviderFactory requires a value for "parameters › fakerstan › psrProvider › phpContainerPath"');
+            throw new RuntimeException(self::class.' requires a value for the "fakerstan.psrProvider.phpContainerPath" parameter');
         }
 
         return new PsrContainerFakerProvider(

--- a/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
@@ -15,7 +15,7 @@ class ContainerClass implements ContainerInterface
         return match ($id) {
             'generatorId' => new Generator(),
             'notGeneratorId' => new \stdClass(),
-            default => throw new class () extends \Exception implements NotFoundExceptionInterface {
+            default => throw new class() extends \Exception implements NotFoundExceptionInterface {
             },
         };
     }

--- a/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;
 
+use Exception;
 use Faker\Generator;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use stdClass;
 
 class ContainerClass implements ContainerInterface
 {
@@ -14,8 +16,8 @@ class ContainerClass implements ContainerInterface
     {
         return match ($id) {
             'generatorId' => new Generator(),
-            'notGeneratorId' => new \stdClass(),
-            default => throw new class() extends \Exception implements NotFoundExceptionInterface {
+            'notGeneratorId' => new stdClass(),
+            default => throw new class() extends Exception implements NotFoundExceptionInterface {
             },
         };
     }

--- a/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/ContainerClass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;
+
+use Faker\Generator;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class ContainerClass implements ContainerInterface
+{
+    public function get(string $id): mixed
+    {
+        return match ($id) {
+            'generatorId' => new Generator(),
+            'notGeneratorId' => new \stdClass(),
+            default => throw new class () extends \Exception implements NotFoundExceptionInterface {
+            },
+        };
+    }
+
+    public function has(string $id): bool
+    {
+        return match ($id) {
+            'generatorId', 'notGeneratorId' => true,
+            default => false,
+        };
+    }
+}

--- a/tests/Fixtures/PsrContainerFakerProviderTest/EmptyContainerFile.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/EmptyContainerFile.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;

--- a/tests/Fixtures/PsrContainerFakerProviderTest/ReturningContainerFile.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/ReturningContainerFile.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;
+
+return new ContainerClass();

--- a/tests/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php
@@ -4,5 +4,7 @@ declare(strict_types=1);
 
 namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;
 
+use stdClass;
+
 $containerVariable = new ContainerClass();
-$nonContainerVariable = new \stdClass();
+$nonContainerVariable = new stdClass();

--- a/tests/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php
+++ b/tests/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan\Tests\Fixtures\PsrContainerFakerProviderTest;
+
+$containerVariable = new ContainerClass();
+$nonContainerVariable = new \stdClass();

--- a/tests/PsrContainerFakerProviderTest.php
+++ b/tests/PsrContainerFakerProviderTest.php
@@ -6,7 +6,6 @@ namespace CalebDW\Fakerstan\Tests;
 
 use CalebDW\Fakerstan\PsrContainerFakerProvider;
 use Faker\Generator;
-use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -15,43 +14,10 @@ use RuntimeException;
 #[CoversClass(PsrContainerFakerProvider::class)]
 class PsrContainerFakerProviderTest extends TestCase
 {
-    private static ?string $temporaryContainerPath = null;
-
-    #[After]
-    public static function cleanUpTemporaryContainer(): void
-    {
-        if (is_string(static::$temporaryContainerPath)) {
-            if (file_exists(static::$temporaryContainerPath)) {
-                unlink(static::$temporaryContainerPath);
-            }
-        }
-
-        static::$temporaryContainerPath = null;
-    }
-
-    /*
-     * Every time we want to include a file for the container, we need to make sure
-     * that it is a new file: otherwise, once one test has included it, the rest
-     * will act differently when they go to do it.
-     */
-    private function containerFilePath(string $containerFixtureFileName): string
-    {
-        $sourceContainerFileName = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/';
-        $sourceContainerFileName .= $containerFixtureFileName;
-
-        static::$temporaryContainerPath = tempnam(sys_get_temp_dir(), 'fakerstan-tests');
-
-        // Make a copy of the source filename in the new (temporary) file, whose name
-        // has hopefully not been included already.
-        copy($sourceContainerFileName, static::$temporaryContainerPath);
-
-        return static::$temporaryContainerPath;
-    }
-
     #[Test]
     public function itUsesContainerReturnedFromFile()
     {
-        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/ReturningContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
         $faker = $sut->getFaker();
 
@@ -61,7 +27,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function itUsesContainerSetInVariable()
     {
-        $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
         $faker = $sut->getFaker();
 
@@ -83,7 +49,7 @@ class PsrContainerFakerProviderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/EmptyContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
         $sut->getFaker();
     }
@@ -93,7 +59,7 @@ class PsrContainerFakerProviderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/EmptyContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
         $sut->getFaker();
     }
@@ -103,7 +69,7 @@ class PsrContainerFakerProviderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/VariableSettingContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, 'nonContainerVariable', 'generatorId');
         $sut->getFaker();
     }
@@ -113,7 +79,7 @@ class PsrContainerFakerProviderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/ReturningContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'id-not-in-container');
         $sut->getFaker();
     }
@@ -123,7 +89,7 @@ class PsrContainerFakerProviderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $containerFilename = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/ReturningContainerFile.php';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'notGeneratorId');
         $sut->getFaker();
     }

--- a/tests/PsrContainerFakerProviderTest.php
+++ b/tests/PsrContainerFakerProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Fakerstan\Tests;
+
+use CalebDW\Fakerstan\PsrContainerFakerProvider;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PsrContainerFakerProvider::class)]
+class PsrContainerFakerProviderTest extends TestCase
+{
+    private static ?string $temporaryContainerPath = null;
+
+    #[After]
+    public static function cleanUpTemporaryContainer(): void
+    {
+        if (is_string(static::$temporaryContainerPath)) {
+            if (file_exists(static::$temporaryContainerPath)) {
+                unlink(static::$temporaryContainerPath);
+            }
+        }
+
+        static::$temporaryContainerPath = null;
+    }
+
+    /*
+     * Every time we want to include a file for the container, we need to make sure
+     * that it is a new file: otherwise, once one test has included it, the rest
+     * will act differently when they go to do it.
+     */
+    private function containerFilePath(string $containerFixtureFileName): string
+    {
+        $sourceContainerFileName = __DIR__.'/Fixtures/PsrContainerFakerProviderTest/';
+        $sourceContainerFileName .= $containerFixtureFileName;
+
+        static::$temporaryContainerPath = tempnam(sys_get_temp_dir(), 'fakerstan-tests');
+
+        // Make a copy of the source filename in the new (temporary) file, whose name
+        // has hopefully not been included already.
+        copy($sourceContainerFileName, static::$temporaryContainerPath);
+
+        return static::$temporaryContainerPath;
+    }
+
+    #[Test]
+    public function getFakerUsesContainerReturnedFromFile()
+    {
+        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
+        $faker = $sut->getFaker();
+
+        self::assertInstanceOf(\Faker\Generator::class, $faker);
+    }
+
+    #[Test]
+    public function getFakerUsesContainerSetInVariable()
+    {
+        $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
+        $faker = $sut->getFaker();
+
+        self::assertInstanceOf(\Faker\Generator::class, $faker);
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenUnableToReadContainerFile()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = __DIR__.'/a-file-that-does-not-exist';
+        $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
+        $sut->getFaker();
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToReturnContainerButDoesNot()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
+        $sut->getFaker();
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToSetAVariableButDoesNot()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
+        $sut->getFaker();
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenTheDeterminedContainerIsNotActuallyAContainer()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, 'nonContainerVariable', 'generatorId');
+        $sut->getFaker();
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenTheContainerDoesNotHaveServiceWithId()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, null, 'id-not-in-container');
+        $sut->getFaker();
+    }
+
+    #[Test]
+    public function getFakerThrowsExceptionWhenTheNamedServiceIsNotAGenerator()
+    {
+        self::expectException(\RuntimeException::class);
+
+        $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
+        $sut = new PsrContainerFakerProvider($containerFilename, null, 'notGeneratorId');
+        $sut->getFaker();
+    }
+}

--- a/tests/PsrContainerFakerProviderTest.php
+++ b/tests/PsrContainerFakerProviderTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace CalebDW\Fakerstan\Tests;
 
 use CalebDW\Fakerstan\PsrContainerFakerProvider;
+use Faker\Generator;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 #[CoversClass(PsrContainerFakerProvider::class)]
 class PsrContainerFakerProviderTest extends TestCase
@@ -53,7 +55,7 @@ class PsrContainerFakerProviderTest extends TestCase
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
         $faker = $sut->getFaker();
 
-        self::assertInstanceOf(\Faker\Generator::class, $faker);
+        self::assertInstanceOf(Generator::class, $faker);
     }
 
     #[Test]
@@ -63,13 +65,13 @@ class PsrContainerFakerProviderTest extends TestCase
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
         $faker = $sut->getFaker();
 
-        self::assertInstanceOf(\Faker\Generator::class, $faker);
+        self::assertInstanceOf(Generator::class, $faker);
     }
 
     #[Test]
     public function getFakerThrowsExceptionWhenUnableToReadContainerFile()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = __DIR__.'/a-file-that-does-not-exist';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
@@ -79,7 +81,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToReturnContainerButDoesNot()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
@@ -89,7 +91,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToSetAVariableButDoesNot()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
@@ -99,7 +101,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheDeterminedContainerIsNotActuallyAContainer()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, 'nonContainerVariable', 'generatorId');
@@ -109,7 +111,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerDoesNotHaveServiceWithId()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'id-not-in-container');
@@ -119,7 +121,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheNamedServiceIsNotAGenerator()
     {
-        self::expectException(\RuntimeException::class);
+        self::expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'notGeneratorId');

--- a/tests/PsrContainerFakerProviderTest.php
+++ b/tests/PsrContainerFakerProviderTest.php
@@ -55,7 +55,7 @@ class PsrContainerFakerProviderTest extends TestCase
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
         $faker = $sut->getFaker();
 
-        self::assertInstanceOf(Generator::class, $faker);
+        $this->assertInstanceOf(Generator::class, $faker);
     }
 
     #[Test]
@@ -65,13 +65,13 @@ class PsrContainerFakerProviderTest extends TestCase
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
         $faker = $sut->getFaker();
 
-        self::assertInstanceOf(Generator::class, $faker);
+        $this->assertInstanceOf(Generator::class, $faker);
     }
 
     #[Test]
     public function getFakerThrowsExceptionWhenUnableToReadContainerFile()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = __DIR__.'/a-file-that-does-not-exist';
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
@@ -81,7 +81,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToReturnContainerButDoesNot()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
@@ -91,7 +91,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToSetAVariableButDoesNot()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('EmptyContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
@@ -101,7 +101,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheDeterminedContainerIsNotActuallyAContainer()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, 'nonContainerVariable', 'generatorId');
@@ -111,7 +111,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheContainerDoesNotHaveServiceWithId()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'id-not-in-container');
@@ -121,7 +121,7 @@ class PsrContainerFakerProviderTest extends TestCase
     #[Test]
     public function getFakerThrowsExceptionWhenTheNamedServiceIsNotAGenerator()
     {
-        self::expectException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'notGeneratorId');

--- a/tests/PsrContainerFakerProviderTest.php
+++ b/tests/PsrContainerFakerProviderTest.php
@@ -49,7 +49,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerUsesContainerReturnedFromFile()
+    public function itUsesContainerReturnedFromFile()
     {
         $containerFilename = $this->containerFilePath('ReturningContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, null, 'generatorId');
@@ -59,7 +59,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerUsesContainerSetInVariable()
+    public function itUsesContainerSetInVariable()
     {
         $containerFilename = $this->containerFilePath('VariableSettingContainerFile.php');
         $sut = new PsrContainerFakerProvider($containerFilename, 'containerVariable', 'generatorId');
@@ -69,7 +69,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenUnableToReadContainerFile()
+    public function itThrowsExceptionWhenUnableToReadContainerFile()
     {
         $this->expectException(RuntimeException::class);
 
@@ -79,7 +79,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToReturnContainerButDoesNot()
+    public function itThrowsExceptionWhenTheContainerFileIsExpectedToReturnContainerButDoesNot()
     {
         $this->expectException(RuntimeException::class);
 
@@ -89,7 +89,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenTheContainerFileIsExpectedToSetAVariableButDoesNot()
+    public function itThrowsExceptionWhenTheContainerFileIsExpectedToSetAVariableButDoesNot()
     {
         $this->expectException(RuntimeException::class);
 
@@ -99,7 +99,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenTheDeterminedContainerIsNotActuallyAContainer()
+    public function itThrowsExceptionWhenTheDeterminedContainerIsNotActuallyAContainer()
     {
         $this->expectException(RuntimeException::class);
 
@@ -109,7 +109,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenTheContainerDoesNotHaveServiceWithId()
+    public function itThrowsExceptionWhenTheContainerDoesNotHaveServiceWithId()
     {
         $this->expectException(RuntimeException::class);
 
@@ -119,7 +119,7 @@ class PsrContainerFakerProviderTest extends TestCase
     }
 
     #[Test]
-    public function getFakerThrowsExceptionWhenTheNamedServiceIsNotAGenerator()
+    public function itThrowsExceptionWhenTheNamedServiceIsNotAGenerator()
     {
         $this->expectException(RuntimeException::class);
 


### PR DESCRIPTION
This pull request defines a FakerProvider (and corresponding factory) for code bases that use a PSR-11 compliant DI container.

Currently it only supports loading the container configuration directly from a PHP file (as opposed to an XML file, say, which is an option in Symfony).

With that limitation, it supports code bases where the container configuration file returns the container directly (eg. in Symfony) or sets the container instance on a variable instead. It also supports an end-user defined ID for retrieving the Generator from the container.